### PR TITLE
Re-approve PRs after updating

### DIFF
--- a/src/github_merge_bot/core.clj
+++ b/src/github_merge_bot/core.clj
@@ -7,7 +7,8 @@
            (org.eclipse.jgit.revwalk RevWalk)
            (org.eclipse.jgit.revwalk.filter RevFilter)
            (org.eclipse.jgit.lib ObjectId)
-           (java.io FileNotFoundException))
+           (java.io FileNotFoundException)
+           (org.eclipse.jgit.api Git))
   (:gen-class))
 
 (defn github-reviews [owner repo pr-id & [options]]
@@ -60,7 +61,7 @@
 
 (defn update-pull-request [owner repo-name pull-request credentials]
   (println "Updating pull request" (:number pull-request) "by rebasing its head branch on master...")
-  (let [repo (procure-repo owner repo-name)
+  (let [^Git repo (procure-repo owner repo-name)
         head (:sha (:head pull-request))
         approved (approved? owner repo-name pull-request)]
     (git/git-fetch repo "origin")


### PR DESCRIPTION
If a PR has been approved before it is updated, it will automatically be re-approved by the bot user after updating it.

I recommend reviewing this PR with the "Hide whitespace changes" option enabled under "Diff settings", as it will allow you to see the diff better.